### PR TITLE
Set default edition to "2018"

### DIFF
--- a/rust-playground.el
+++ b/rust-playground.el
@@ -63,6 +63,7 @@ By default confirmation required."
 name = \"foo\"
 version = \"0.1.0\"
 authors = [\"Rust Example <rust-snippet@example.com>\"]
+edition = \"2018\"
 
 [dependencies]"
   "When creating a new playground, this will be used as the Cargo.toml file")


### PR DESCRIPTION
Thanks for this project!

This minor PR adds a line to the `Cargo.toml` config file that tells Rust to use the 2018-Edition version of the language (which has a few minor changes from the 2015 version that is used without that line).  This is probably the behavior most users expect in 2020 (and is part of the default configuration generated by `cargo init`).

I would normally have opened an issue before submitting a PR but, since you mentioned that this project is not a high priority and because this change was so minor, I decided to make an exception in this case—apologies if you would have preferred an issue. 