### PR TITLE
save main.rs buffer on startup

### DIFF
--- a/rust-playground.el
+++ b/rust-playground.el
@@ -153,6 +153,7 @@ Otherwise message the user that they aren't in one."
     (set-visited-file-name snippet-file-name t)
     (rust-playground-insert-template-head "snippet of code" snippet-dir)
     (insert rust-playground-main-rs-template)
+    (save-buffer)
     ;; back up to a good place to edit from
     (backward-char 27)
     (rust-playground-mode)))


### PR DESCRIPTION
Without this, 

* `rust-analyzer` will complain.
* if you do `rust-playground-rm` before saving main.rs, the main.rs buffer will remain opened.